### PR TITLE
Refactor for readability

### DIFF
--- a/.vscode/general.code-snippets
+++ b/.vscode/general.code-snippets
@@ -1,0 +1,7 @@
+{
+  "extension_import": {
+    "scope": "dart",
+    "prefix": "extension_import",
+    "body": "import 'package:$WORKSPACE_NAME/src/extensions$0';"
+  }
+}

--- a/lib/src/extensions/element_extensions.dart
+++ b/lib/src/extensions/element_extensions.dart
@@ -1,0 +1,9 @@
+import 'package:html/dom.dart';
+import 'package:openapi_client_builder/src/schema/member_template.dart';
+
+extension ElementExtension on Element {
+  List<MemberTemplate> toMemberTemplates() =>
+      (text.split('\n')..removeRange(0, 2))
+          .map<MemberTemplate>((row) => MemberTemplate(row))
+          .toList();
+}

--- a/lib/src/extensions/list_extensions.dart
+++ b/lib/src/extensions/list_extensions.dart
@@ -1,0 +1,5 @@
+extension ListExtension on List {
+  T elementAtOrNull<T>(int index) => index >= length ? null : elementAt(index);
+  T firstOrNull<T>() => isEmpty ? null : first;
+  T lastOrNull<T>() => isEmpty ? null : last;
+}

--- a/lib/src/extensions/list_of_element_extensions.dart
+++ b/lib/src/extensions/list_of_element_extensions.dart
@@ -1,0 +1,6 @@
+import 'package:html/dom.dart';
+
+extension ListOfElement on List<Element> {
+  String toCommentsString() =>
+      map<String>((tag) => tag.text.replaceAll('\n', '\n/// ')).join('\n/// ');
+}

--- a/lib/src/extensions/list_of_member_template_extension.dart
+++ b/lib/src/extensions/list_of_member_template_extension.dart
@@ -7,4 +7,15 @@ extension ListOfMemberTemplateExtension on List<MemberTemplate> {
 
   String toInilitializersString() =>
       map<String>((member) => '_${member.name} = ${member.name}').join(', ');
+
+  String toGettersString() => map<String>((member) =>
+          '  ${member.typeValue} get ${member.name} => _${member.name};')
+      .join('\n');
+
+  String toInitializersForFromJson() =>
+      map<String>((member) => member.fromJsonString).join(',\n');
+
+  String toDeclarationsString() => map<String>((member) =>
+          '  /// ${member.comment}\n  final ${member.typeValue} _${member.name};')
+      .join('\n');
 }

--- a/lib/src/extensions/list_of_member_template_extension.dart
+++ b/lib/src/extensions/list_of_member_template_extension.dart
@@ -1,0 +1,10 @@
+import 'package:openapi_client_builder/src/schema/member_template.dart';
+
+extension ListOfMemberTemplateExtension on List<MemberTemplate> {
+  String toConstructorString() => map<String>((member) =>
+      (member.isRequired ? 'required ' : '') +
+      '${member.typeValue} ${member.name}').join(', ');
+
+  String toInilitializersString() =>
+      map<String>((member) => '_${member.name} = ${member.name}').join(', ');
+}

--- a/lib/src/schema/class_template.dart
+++ b/lib/src/schema/class_template.dart
@@ -2,6 +2,7 @@ import 'package:html/dom.dart';
 import 'package:openapi_client_builder/src/enums/fields_type.dart';
 import 'package:openapi_client_builder/src/schema/member_template.dart';
 import 'package:openapi_client_builder/src/extensions/list_of_element_extensions.dart';
+import 'package:openapi_client_builder/src/extensions/list_of_member_template_extension.dart';
 
 /// The first pass of parsing the spec document has produced a set data items,
 /// each corresponding to a schema that we want a class template for.
@@ -25,15 +26,9 @@ class ClassTemplate {
         tableRows.map<MemberTemplate>((row) => MemberTemplate(row)).toList();
 
     // Iterate over members, creating parts of the class template.
-    _constructorString = _classMembers
-        .map<String>((member) =>
-            (member.isRequired ? 'required ' : '') +
-            '${member.typeValue} ${member.name}')
-        .join(', ');
 
-    _initializerListString = _classMembers
-        .map<String>((member) => '_${member.name} = ${member.name}')
-        .join(', ');
+    _constructorString = _classMembers.toConstructorString();
+    _initializersString = _classMembers.toInilitializersString();
 
     if (_fieldsType == FieldsType.patterned) {
       _patternedMemberString =
@@ -64,7 +59,7 @@ class ClassTemplate {
   late final String _classComment;
   late final List<MemberTemplate> _classMembers;
   late final String _constructorString;
-  late final String _initializerListString;
+  late final String _initializersString;
   late final String _combinedClassMembersString;
   late final String _patternedMemberString;
   late final String _gettersString;
@@ -89,7 +84,7 @@ class $_className {
 
 /// $_classComment
 class $_className {
-  $_className({$_constructorString}) : $_initializerListString;
+  $_className({$_constructorString}) : $_initializersString;
 
 $_combinedClassMembersString
 

--- a/lib/src/schema/class_template_patterned.dart
+++ b/lib/src/schema/class_template_patterned.dart
@@ -1,0 +1,34 @@
+import 'package:html/dom.dart';
+import 'package:openapi_client_builder/src/schema/class_template.dart';
+
+class ClassTemplatePatterned extends ClassTemplate {
+  ClassTemplatePatterned(
+      {required Element classNameTag,
+      required List<Element> classCommentTags,
+      required Element tableTag})
+      : super(
+            classNameTag: classNameTag,
+            classCommentTags: classCommentTags,
+            tableTag: tableTag) {
+    _patternedMemberString =
+        firstMemberName.replaceAll(RegExp(r'{|}'), '') + 'Map';
+  }
+
+  late final String _patternedMemberString;
+
+  @override
+  String get output => '''
+
+/// $classComment
+class $className {
+  $className();
+
+  Map<String, PathItem> $_patternedMemberString = {};
+
+  $className.fromJson(Map<String, dynamic> json) : 
+    $_patternedMemberString = {}..addEntries(json.entries.map(
+      (entry) => MapEntry(entry.key, PathItem.fromJson(entry.value))));
+}
+
+''';
+}

--- a/lib/src/schema/utility_functions.dart
+++ b/lib/src/schema/utility_functions.dart
@@ -1,6 +1,8 @@
 import 'package:html/dom.dart';
+import 'package:openapi_client_builder/src/enums/fields_type.dart';
 import 'package:openapi_client_builder/src/schema/class_template.dart';
 import 'package:openapi_client_builder/src/extensions/string_extensions.dart';
+import 'package:openapi_client_builder/src/schema/class_template_patterned.dart';
 
 List<ClassTemplate> extractClassTemplates(Document document) {
   final list = <ClassTemplate>[];
@@ -28,12 +30,17 @@ List<ClassTemplate> extractClassTemplates(Document document) {
     if (tableTag == null || tableTag.text.split('\n').length < 3) continue;
 
     // Split up the table into rows and remove the formatting.
-    list.add(ClassTemplate(
-      fieldsType: nextTag.text.toFieldsType(),
-      classNameTag: classNameTag,
-      classCommentTags: classCommentTags,
-      tableRows: tableTag.text.split('\n')..removeRange(0, 2),
-    ));
+    list.add((nextTag.text.toFieldsType() == FieldsType.fixed
+        ? ClassTemplate(
+            classNameTag: classNameTag,
+            classCommentTags: classCommentTags,
+            tableTag: tableTag,
+          )
+        : ClassTemplatePatterned(
+            classNameTag: classNameTag,
+            classCommentTags: classCommentTags,
+            tableTag: tableTag,
+          )));
   }
 
   return list;


### PR DESCRIPTION
- added extension on Element for readability
- added extensions on List<MemberType> for readability
- added a subclass of ClassTemplate to deal with the special
  case of patterned field types
- cleaned up ClassTemplate and added getters for subtype to access
  - this moved field type logic out of ClassTemplate so
  extractClassTemplates now creates the appropriate class